### PR TITLE
[272528765] allow use CatalogHeader[] type for catalog_headers field in SyncCatalogRequest

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ export {
     toTimeString,
     toJson,
     fromJson,
+    prepareHeadersForCatalogApiRequest,
 } from "./src/helpers/functions";
 export {ApiError} from "./src/helpers/errors";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pyrus-api",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "description": "Pyrus API client for TypeScript",
     "repository": {
         "type": "git",

--- a/src/api/catalogsApi.ts
+++ b/src/api/catalogsApi.ts
@@ -4,8 +4,12 @@ import {ById} from "../helpers/types";
 import {CatalogsResponse} from "../responses/catalogsResponse";
 import {CatalogResponse} from "../responses/catalogResponse";
 import {CreateCatalogRequest} from "../requests/createCatalogRequest";
-import {SyncCatalogRequest} from "../requests/syncCatalogRequest";
+import {
+    SyncCatalogRequest,
+    SyncCatalogRequestApi,
+} from "../requests/syncCatalogRequest";
 import {SyncCatalogResponse} from "../responses/syncCatalogResponse";
+import {prepareHeadersForCatalogApiRequest} from "../helpers/functions";
 
 export class CatalogsApi extends BaseApi {
     protected _moduleSubPath = Endpoints.Catalogs;
@@ -40,10 +44,17 @@ export class CatalogsApi extends BaseApi {
      * @param request
      */
     public async sync(request: SyncCatalogRequest) {
+        const apiRequest: SyncCatalogRequestApi = {
+            ...request,
+            catalog_headers: prepareHeadersForCatalogApiRequest(
+                request.catalog_headers,
+            ),
+        };
+
         return await this.fetchApi<SyncCatalogResponse>(
             (await this.getModulePath()) + `/${request.id}`,
             "POST",
-            JSON.stringify(request),
+            JSON.stringify(apiRequest),
         );
     }
 }

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -9,6 +9,7 @@ import {
 } from "./constants";
 import {FormFilter} from "../requests/formFilter";
 import {OperatorId} from "../enums/operatorId";
+import {CatalogHeader} from "../entities/catalogHeader";
 
 export function toSearchParams(request: object) {
     return (
@@ -126,4 +127,12 @@ export function processFilters(filters: FormFilter[] | undefined) {
 
         return prev;
     }, {});
+}
+
+export function prepareHeadersForCatalogApiRequest(
+    headers: string[] | CatalogHeader[],
+): string[] {
+    return headers.map((header) =>
+        typeof header === "string" ? header : header.name,
+    );
 }

--- a/src/requests/syncCatalogRequest.ts
+++ b/src/requests/syncCatalogRequest.ts
@@ -1,7 +1,15 @@
 import {CatalogRequestBase} from "./catalogRequestBase";
+import {CatalogHeader} from "../entities/catalogHeader";
 
-export type SyncCatalogRequest = CatalogRequestBase & {
+export type SyncCatalogRequestApi = CatalogRequestBase & {
     id: number;
     apply: boolean;
     force_update_first_column?: boolean;
+};
+
+export type SyncCatalogRequest = Omit<
+    SyncCatalogRequestApi,
+    "catalog_headers"
+> & {
+    catalog_headers: string[] | CatalogHeader[];
 };


### PR DESCRIPTION
https://pyrus.com/t#id272528765

Upgrade **package version to 2.3.0** due to new feature.

- allow use `CatalogHeader[]` type for `catalog_headers` field in `SyncCatalogRequest`