### PR TITLE
[297586057] FormField.Id is always returned by the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pyrus-api",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "Pyrus API client for TypeScript",
     "repository": {
         "type": "git",

--- a/src/entities/formFields/formField.ts
+++ b/src/entities/formFields/formField.ts
@@ -23,9 +23,9 @@ import {FormFieldTable} from "./formFieldTable";
 import {FormFieldText} from "./formFieldText";
 import {FormFieldTime} from "./formFieldTime";
 import {FormFieldTitle} from "./formFieldTitle";
-import {IdOrCodeRequired} from "../../helpers/types";
+import {IdOrCodeRequired, IdRequired} from "../../helpers/types";
 
-export type FormField =
+type FormFieldCommon =
     | FormFieldAuthor
     | FormFieldCatalog
     | FormFieldCheckmark
@@ -52,4 +52,6 @@ export type FormField =
     | FormFieldTime
     | FormFieldTitle;
 
-export type FormFieldIdentified = FormField & IdOrCodeRequired;
+export type FormField = FormFieldCommon & IdRequired;
+
+export type FormFieldIdentified = FormFieldCommon & IdOrCodeRequired;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,12 +1,13 @@
 export type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE";
-export type ById = {
+
+export type IdRequired = {
     id: number;
 };
 
-export type IdOrCodeRequired =
-    | {
-          id: number;
-      }
-    | {
-          code: string;
-      };
+type CodeRequired = {
+    code: string;
+};
+
+export type ById = IdRequired;
+
+export type IdOrCodeRequired = IdRequired | CodeRequired;


### PR DESCRIPTION
https://pyrus.com/t#297586057

Upgrade **package version to 2.4.1** due to fix type.

- mark `Id` field in the `FormField` type as required  