### PR TITLE
Add setDefaults to override default API URLs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -87,3 +87,7 @@ export type {BotHookResponse} from "./src/responses/botHookResponse";
 
 // client
 export {PyrusApiClient} from "./src/api";
+
+// settings
+export {setDefaults} from "./src/settings/defaults";
+export type {Settings} from "./src/entities/settings";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyrus-api",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyrus-api",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "license": "MIT",
             "devDependencies": {
                 "@rollup/plugin-typescript": "^11.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pyrus-api",
     "description": "Pyrus API client for TypeScript",
-    "version": "3.8.0",
+    "version": "3.9.0",
     "author": {
         "name": "Pyrus",
         "email": "contact@pyrus.com"

--- a/src/settings/defaults.test.ts
+++ b/src/settings/defaults.test.ts
@@ -1,0 +1,49 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {defaults, setDefaults} from "./defaults";
+import {PyrusApiClient} from "../api";
+
+const originalDefaults = {...defaults};
+
+afterEach(() => {
+    setDefaults(originalDefaults);
+    vi.restoreAllMocks();
+});
+
+describe("setDefaults", () => {
+    it("overrides only the provided fields and trims the trailing slash", () => {
+        setDefaults({apiUrl: "https://api.example.com/v4/"});
+
+        expect(defaults.apiUrl).toBe("https://api.example.com/v4");
+        // other fields are left untouched
+        expect(defaults.authUrl).toBe(originalDefaults.authUrl);
+        expect(defaults.filesUrl).toBe(originalDefaults.filesUrl);
+    });
+
+    it("ignores empty/undefined values", () => {
+        setDefaults({authUrl: "", apiUrl: undefined});
+
+        expect(defaults.authUrl).toBe(originalDefaults.authUrl);
+        expect(defaults.apiUrl).toBe(originalDefaults.apiUrl);
+    });
+
+    it("a client without settings uses the overridden authUrl", async () => {
+        setDefaults({authUrl: "https://accounts.example.com/api/v4"});
+
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({access_token: "t"}), {
+                status: 200,
+                headers: {"Content-Type": "application/json"},
+            }),
+        );
+
+        const client = new PyrusApiClient({
+            login: "bot@b.com",
+            security_key: "key",
+        });
+        // wait for the auth request started in the constructor
+        await (client as any)._authRequest;
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as string;
+        expect(requestedUrl).toBe("https://accounts.example.com/api/v4/auth");
+    });
+});

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -1,7 +1,18 @@
 import {Settings} from "../entities/settings";
+import {trimTrailingSlash} from "../helpers/functions";
 
 export const defaults: Settings = {
     authUrl: "https://accounts.pyrus.com/api/v4",
     apiUrl: "https://api.pyrus.com/v4",
     filesUrl: "https://files.pyrus.com",
 };
+
+// Overrides the default URLs used by clients created without explicit settings.
+// Only the provided fields are applied; empty/undefined values are ignored.
+export function setDefaults(settings: Partial<Settings>): void {
+    if (settings.authUrl)
+        defaults.authUrl = trimTrailingSlash(settings.authUrl);
+    if (settings.apiUrl) defaults.apiUrl = trimTrailingSlash(settings.apiUrl);
+    if (settings.filesUrl)
+        defaults.filesUrl = trimTrailingSlash(settings.filesUrl);
+}


### PR DESCRIPTION
Public setDefaults(settings) mutates the shared defaults object, so clients created without explicit settings use the provided authUrl/apiUrl/filesUrl. Bump version 3.8.0 -> 3.9.0.